### PR TITLE
Correction of cross-entropy loss computation

### DIFF
--- a/scratchgan/experiment.py
+++ b/scratchgan/experiment.py
@@ -196,7 +196,6 @@ def train(config):
                                                      targets_real)
     loss_fake = losses.sequential_cross_entropy_loss(disc_logits_fake,
                                                      targets_fake)
-    disc_loss = 0.5 * loss_real + 0.5 * loss_fake
 
   # Loss of the generator.
   gen_loss, cumulative_rewards, baseline = losses.reinforce_loss(

--- a/scratchgan/experiment.py
+++ b/scratchgan/experiment.py
@@ -216,8 +216,10 @@ def train(config):
   gen_vars = gen.get_all_variables()
   l2_disc = tf.reduce_sum(tf.add_n([tf.nn.l2_loss(v) for v in disc_vars]))
   l2_gen = tf.reduce_sum(tf.add_n([tf.nn.l2_loss(v) for v in gen_vars]))
-  scalar_disc_loss = tf.reduce_mean(disc_loss) + config.l2_disc * l2_disc
-  scalar_gen_loss = tf.reduce_mean(gen_loss) + config.l2_gen * l2_gen
+  scalar_loss_real = tf.reduce_sum(loss_real) / tf.reduce_sum(real_sentence_length)
+  scalar_loss_fake = tf.reduce_sum(loss_fake) / tf.reduce_sum(gen_outputs["sequence_length"])
+  scalar_disc_loss = 0.5 * scalar_loss_real + 0.5 * scalar_loss_fake + config.l2_disc * l2_disc
+  scalar_gen_loss = tf.reduce_sum(gen_loss) / tf.reduce_sum(gen_outputs["sequence_length"]) + config.l2_gen * l2_gen
 
   # Update ops.
   global_step = tf.train.get_or_create_global_step()


### PR DESCRIPTION
The computation of cross-entropy error should only consider valid values.