### PR TITLE
Update requirements.txt with optex.

### DIFF
--- a/byol/requirements.txt
+++ b/byol/requirements.txt
@@ -4,5 +4,7 @@ dm-tree
 jax
 jaxlib
 numpy>=1.16
+optax
 tensorflow
 tensorflow_datasets
+


### PR DESCRIPTION
This requirement is missing from requirements.txt, and is used for the LARS implementation in optimizers.py.