### PR TITLE
Remove apt update command from travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     # - PROJECT="unrestricted_advx"  # TODO(b/184862249): Fix and enable
     - PROJECT="unsupervised_adversarial_training"
 before_script:
-  - sudo apt-get update -qq
   - pip install --upgrade pip
   - pip install --upgrade virtualenv
   - pip install --upgrade wheel


### PR DESCRIPTION
It's not necessary for the tests and it breaks CI due to missing keys.