### PR TITLE
Fix gin-config compatibility error in rl_unplugged notebooks

### DIFF
--- a/rl_unplugged/atari_dqn.ipynb
+++ b/rl_unplugged/atari_dqn.ipynb
@@ -60,6 +60,7 @@
         "!pip install dm-acme[reverb]\n",
         "!pip install dm-acme[tf]\n",
         "!pip install dm-sonnet\n",
+        "!pip install gin-config==0.3.0\n",
         "!pip install dopamine-rl==3.1.2\n",
         "!pip install atari-py\n",
         "!git clone https://github.com/deepmind/deepmind-research.git\n",

--- a/rl_unplugged/bsuite.ipynb
+++ b/rl_unplugged/bsuite.ipynb
@@ -49,6 +49,7 @@
         "!pip install dm-acme[reverb]\n",
         "!pip install dm-acme[tf]\n",
         "!pip install dm-sonnet\n",
+        "!pip install gin-config==0.3.0\n",
         "!pip install dopamine-rl==3.1.2\n",
         "!pip install atari-py\n",
         "!pip install dm_env\n",


### PR DESCRIPTION
Fixes #428

## Problem

Running `from rl_unplugged import atari` in Colab raises:

`
TypeError: configurable() got an unexpected keyword argument 'blacklist'
`

This occurs because `dopamine-rl==3.1.2` uses gin-config's deprecated `blacklist` parameter, which was renamed to `denylist` in newer gin-config versions.

## Solution

Pin `gin-config==0.3.0` in the notebook installation cells, consistent with what's already specified in `requirements.txt`.

## Changes

- `atari_dqn.ipynb`: Added `!pip install gin-config==0.3.0` before dopamine-rl
- `bsuite.ipynb`: Added `!pip install gin-config==0.3.0` before dopamine-rl

Note: The `dmlab_r2d2.ipynb` bazel build issue mentioned in #428 is a separate infrastructure problem with DeepMind Lab that requires upstream fixes.